### PR TITLE
fixing crash for a inline image

### DIFF
--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -334,7 +334,8 @@ namespace GeeksWithBlogsToMarkdown.ViewModels
 
                         progressController.SetMessage($"{message}\nDownloading images in post...{imageCount} of {totalImages}");
                         var client = new WebClient();
-
+                        if (url.Value.StartsWith("data:image"))
+                            continue;
                         var imageUri = new Uri(url.Value);
                         var twoWordsFromPost = blogPost.Title.ToLower().Split(' ').Take(4);
                         var imageName = $"{blogPost.DateCreated.ToString("yyyy_MM_dd")}_{string.Join("_", twoWordsFromPost)}_Image{imageCount}{Path.GetExtension(imageUri.AbsoluteUri)}";


### PR DESCRIPTION
I am watching this repos from year. Today I was running this app and find that it's breaking when it's try to download a image which is inline image (data:images in html).

A fix for this is escape those file which is not the image or secondly we can download those image with some name( Maybe from post title etc).

@jamiehowarth0  @onlyutkarsh 

